### PR TITLE
change wallet address after Ravonus request

### DIFF
--- a/data/arg-winners.json
+++ b/data/arg-winners.json
@@ -297,7 +297,7 @@
   {
     "rank": 60,
     "user": "Ravonus",
-    "wallet": "0xB2A150290834f7CAbD6CB5275Ae610821d978cF4"
+    "wallet": "0x30e64B8E4bacc2BAEf74AC59D33aB230A2889d50"
   },
   {
     "rank": 61,


### PR DESCRIPTION
Original request from the user: "Can I change my Wallet ID for the arg? I gave my Burner wallet and want to use my main one."